### PR TITLE
The program fails when the user has no submissions

### DIFF
--- a/hacker_news_to_sqlite/cli.py
+++ b/hacker_news_to_sqlite/cli.py
@@ -24,11 +24,13 @@ def user(db_path, username):
     user = requests.get(
         "https://hacker-news.firebaseio.com/v0/user/{}.json".format(username)
     ).json()
-    submitted = user.pop("submitted", None) or []
-    with db.conn:
-        db["users"].upsert(
-            user, column_order=("id", "created", "karma", "about"), pk="id"
-        )
+    submitted = []
+    if user:
+        submitted = user.pop("submitted", None) or []
+        with db.conn:
+            db["users"].upsert(
+                user, column_order=("id", "created", "karma", "about"), pk="id"
+            )
     # Only do IDs we have not yet fetched
     done = set()
     if "items" in db.table_names():


### PR DESCRIPTION
Tested with:
    
     hacker-news-to-sqlite user hacker-news.db fernand0

Result:
`
Traceback (most recent call last):
  File "/home/ftricas/.pyenv/versions/3.10.6/bin/hacker-news-to-sqlite", line 8, in <module>
    sys.exit(cli())
  File "/home/ftricas/.pyenv/versions/3.10.6/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/ftricas/.pyenv/versions/3.10.6/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/ftricas/.pyenv/versions/3.10.6/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ftricas/.pyenv/versions/3.10.6/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ftricas/.pyenv/versions/3.10.6/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/ftricas/.pyenv/versions/3.10.6/lib/python3.10/site-packages/hacker_news_to_sqlite/cli.py", line 27, in user
    submitted = user.pop("submitted", None) or []
AttributeError: 'NoneType' object has no attribute 'pop'
`

There is a problem of style with the patch (but not sure what to do) because with the new inicialization ( submitted = []) the part 

     or []

is not needed. Maybe there is a more adequate way of doing this.