### PR TITLE
Add permalink virtual field to items table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv
 .eggs
 .pytest_cache
 *.egg-info
+build

--- a/README.md
+++ b/README.md
@@ -78,3 +78,25 @@ Run Datasette like this:
     $ datasette -m metadata.json hacker-news.db
 
 The timestamp columns will now be rendered as human-readable dates, and any HTML in your posts will be displayed as rendered HTML.
+
+## Package Development
+
+After cloning, install the dependencies (preferably in a virtual environment):
+
+```sh
+pip install --editable '.[test]'
+```
+
+This gives you everything you need to run and develop the package. Running the tests should now work:
+
+```sh
+pytest
+```
+
+As you make changes to the code, you can re-run it using:
+
+```sh
+.venv/bin/hacker-news-to-sqlite
+```
+
+Which should reflect your changes immediately.

--- a/hacker_news_to_sqlite/cli.py
+++ b/hacker_news_to_sqlite/cli.py
@@ -124,6 +124,15 @@ def ensure_tables(db):
             {"id": int, "type": str, "by": str, "time": int, "title": str, "text": str},
             pk="id",
         )
+    # includes hidden columns
+    all_column_names = {
+        c[1] for c in db.execute("PRAGMA table_xinfo([items])").fetchall()
+    }
+    if "permalink" not in all_column_names:
+        db.execute(
+            'ALTER TABLE items ADD COLUMN permalink TEXT GENERATED ALWAYS as ("https://news.ycombinator.com/item?id=" || id) VIRTUAL;'
+        )
+
     if "users" not in db.table_names():
         db["users"].create(
             {"id": str, "created": int, "karma": int, "about": str}, pk="id"

--- a/tests/test_hacker_news_to_sqlite.py
+++ b/tests/test_hacker_news_to_sqlite.py
@@ -72,6 +72,7 @@ def test_import_user(tmpdir, requests_mock):
             "time": 1583377246,
             "kids": "[22491039, 22490633, 22491277, 22492319, 22490883, 22491996, 22502812, 22491049, 22491052, 22491001, 22490704]",
             "parent": 22485489,
+            'permalink': 'https://news.ycombinator.com/item?id=22490556',
             "text": "The approach that has worked best for me is...",
             "title": None,
         }


### PR DESCRIPTION
I added a virtual column (no storage overhead) to the output that easily links back to the source. It works nicely out of the box with datasette:

![](https://cdn.zappy.app/faf43661d539ee0fee02c0421de22d65.png)

I got bit a bit by https://github.com/simonw/sqlite-utils/issues/411, so I went with a manual `table_xinfo` and creating the table via execute. Happy to adjust if that issue moves, but this seems like it works.

I also added my best-guess instructions for local development on this package. I'm shooting in the dark, so feel free to replace with how you work on it locally.